### PR TITLE
UI: Fix 404 when accessing an url with path directly

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,3 +1,4 @@
 node_modules/
 tmp/
 config/
+build/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -23,4 +23,6 @@ USER nginx
 
 EXPOSE 8080
 
+COPY image/nginx.conf /etc/nginx/conf.d/default.conf
+
 CMD /usr/bin/start.sh

--- a/frontend/image/nginx.conf
+++ b/frontend/image/nginx.conf
@@ -1,0 +1,46 @@
+server {
+    listen       8080;
+    server_name  localhost;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri /index.html;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
-  "homepage": "./",
+  "homepage": "/",
   "dependencies": {
     "@patternfly/react-charts": "^5.0.13",
     "@patternfly/react-core": "^3.112.3",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -8,7 +8,7 @@
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="All Things Tekton" />
   <link rel="apple-touch-icon" href="logo192.png" />
-  <link rel="stylesheet" href="index.css">
+  <link rel="stylesheet" href="%PUBLIC_URL%/index.css">
   <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
@@ -31,16 +31,6 @@
 <body>
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
-  <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
 </body>
 
 </html>


### PR DESCRIPTION
Earlier when user tries to access a url which contains a path,
Nginx would throw a 404 as the "path" does not translate to an
actual file on disk. This is fixed by returning "index.html"

Signed-off-by: Sunil Thaha <sthaha@redhat.com>